### PR TITLE
Add preview check to popup filter to avoid elementor breaking

### DIFF
--- a/trunk/Public/DynamicConditionsPublic.php
+++ b/trunk/Public/DynamicConditionsPublic.php
@@ -241,6 +241,10 @@ class DynamicConditionsPublic {
      * @param Locations_Manager $locationManager
      */
     public function checkPopupsCondition( $locationManager ) {
+        if ( Plugin::$instance->preview->is_preview_mode() ) {
+            return;
+        }
+
         $conditionManager = Module::instance()->get_conditions_manager();
         $module = $conditionManager->get_documents_for_location( 'popup' );
 

--- a/trunk/Public/DynamicConditionsPublic.php
+++ b/trunk/Public/DynamicConditionsPublic.php
@@ -241,9 +241,10 @@ class DynamicConditionsPublic {
      * @param Locations_Manager $locationManager
      */
     public function checkPopupsCondition( $locationManager ) {
-        if ( Plugin::$instance->preview->is_preview_mode() ) {
+        if ( ! empty( Plugin::$instance->preview ) && Plugin::$instance->preview->is_preview_mode() ) {
             return;
         }
+
 
         $conditionManager = Module::instance()->get_conditions_manager();
         $module = $conditionManager->get_documents_for_location( 'popup' );


### PR DESCRIPTION
This PR adds an  preview check to the popup filter. 
It's necessary to add this, because of the fact that the event which was used to detect popups.
Is also executed by the preview and can lead to a break of Elementor as mentioned in #19.